### PR TITLE
Remove indentation

### DIFF
--- a/draft/index.html
+++ b/draft/index.html
@@ -1,105 +1,108 @@
 <!DOCTYPE html>
 <html lang="de">
-    <head>
-        <meta charset='utf-8'>
-        <title>Service Card for Open Educational Resources</title>
-        <script src='https://w3c.github.io/respec/builds/respec-dini.js' async class='remove'></script>
-        <script class='remove'>
-            var respecConfig = {
-                editors: [{
-                    name: "Adrian Pohl"
-                }, {
-                    name: "Annett Zobel"
-                }, {
-                    name: "Matthias Hupfer"
-                }, {
-                    name: "Steffen Hippeli"
-                }, {
-                    name: "Torsten Simon"
-                }],
-                format: "markdown",
-                localBiblio: {
-                    "LRMI": {
-                        title: "LRMI Concept Schemes",
-                        href: "https://www.dublincore.org/specifications/lrmi/concept_schemes/",
-                        publisher: "DCMI"
-                    },
-                    "schema.org": {
-                        title: "schema.org Vocabulary",
-                        href: "https://schema.org",
-                        publisher: "W3C"
-                    }
+<head>
+    <meta charset='utf-8'>
+    <title>Service Card for Open Educational Resources</title>
+    <script src='https://w3c.github.io/respec/builds/respec-dini.js' async class='remove'></script>
+    <script class='remove'>
+        var respecConfig = {
+            editors: [{
+                name: "Adrian Pohl"
+            }, {
+                name: "Annett Zobel"
+            }, {
+                name: "Matthias Hupfer"
+            }, {
+                name: "Steffen Hippeli"
+            }, {
+                name: "Torsten Simon"
+            }],
+            format: "markdown",
+            localBiblio: {
+                "LRMI": {
+                    title: "LRMI Concept Schemes",
+                    href: "https://www.dublincore.org/specifications/lrmi/concept_schemes/",
+                    publisher: "DCMI"
                 },
-                logos: [],
-                otherLinks: [{
-                    key: "Links zur Spezifikation",
-                    data: [{
-                        value: "Permalink zur aktuellsten Version",
-                        href: "https://w3id.org/kim/oer-service-card/latest/"
+                "schema.org": {
+                    title: "schema.org Vocabulary",
+                    href: "https://schema.org",
+                    publisher: "W3C"
+                }
+            },
+            logos: [],
+            otherLinks: [{
+                key: "Links zur Spezifikation",
+                data: [{
+                    value: "Permalink zur aktuellsten Version",
+                    href: "https://w3id.org/kim/oer-service-card/latest/"
 //                    }, {
 //                        value: "Permalink zu dieser Version",
 //                        href: "https://w3id.org/kim/oer-service-card/[version]/" // Add [version] when publishing new spec version!
-                    }, {
-                        value: "Letzter Entwurf zur Kommentierung",
-                        href: "https://w3id.org/kim/oer-service-card/draft/"
-                    }]
                 }, {
-                    key: "Mitmachen",
-                    data: [{
-                        value: "GitHub-Repository",
-                        href: "https://github.com/dini-ag-kim/oer-service-card/"
-                    }, {
-                        value: "Änderungshistorie",
-                        href: "https://github.com/dini-ag-kim/oer-service-card/commits/master"
-                    }]
-                }],
-                publishDate: "", // Add publication date when publishing new spec version!
-                specStatus: "unofficial", // Change to "base" when publishing new spec version!
-                subtitle: "Harmonisierungsempfehlung der OER-Metadaten AG"
-            };
-        </script>
-    </head>
-    <body>
-        <section id="abstract" data-include="contents/abstract.md"></section>
+                    value: "Letzter Entwurf zur Kommentierung",
+                    href: "https://w3id.org/kim/oer-service-card/draft/"
+                }]
+            }, {
+                key: "Mitmachen",
+                data: [{
+                    value: "GitHub-Repository",
+                    href: "https://github.com/dini-ag-kim/oer-service-card/"
+                }, {
+                    value: "Änderungshistorie",
+                    href: "https://github.com/dini-ag-kim/oer-service-card/commits/master"
+                }]
+            }],
+            publishDate: "", // Add publication date when publishing new spec version!
+            specStatus: "unofficial", // Change to "base" when publishing new spec version!
+            subtitle: "Harmonisierungsempfehlung der OER-Metadaten AG"
+        };
+    </script>
+</head>
+<body>
+<section id="abstract" data-include="contents/abstract.md"></section>
 
-        <section id="conformance" data-include="contents/conformance.md"></section>
+<section id="conformance" data-include="contents/conformance.md"></section>
 
-        <section id="technical-spec">
-            <h2>Implementierung</h2>
+<section id="technical-spec">
+<h2>Implementierung</h2>
 
-            <section id="format" data-include="contents/format.md">
-                <h2>Format</h2>
-            </section>
- 
-            <section id="vocabulary" data-include="contents/vocabulary.md">
-                <h2>Vokabular</h2>
-            </section>
+<section id="format" data-include="contents/format.md">
+<h2>Format</h2>
+</section>
 
-            <section id="examples">
-                <h2>Beispiele</h2>
+<section id="vocabulary" data-include="contents/vocabulary.md">
+<h2>Vokabular</h2>
+</section>
 
-                <section id="full-example">
-                    <h2>Vollständiges Beispiel</h2>
-                    <pre class="example" data-include="examples/full-example.json" data-include-format="text"></pre>
-                </section>
-            </section>
-        </section>
+<section id="examples">
+<h2>Beispiele</h2>
 
-        <section id="schemas">
-            <h2>Validierung</h2>
+<section id="full-example">
+<h2>Vollständiges Beispiel</h2>
+<pre class="example" data-include="examples/full-example.json" data-include-format="text"></pre>
+</section>
 
-            <section id="json-schema">
-                <h2>JSON Schema</h2>
-                <pre data-include="schemas/service-card.json" data-include-format="text"></pre>
-                <a href="schemas/service-card.json">Link zum Schema</a>
-            </section>
-        </section>
+</section>
 
-        <section id="glossary" class="appendix" data-include="contents/glossary.md">
-            <h2>Glossar</h2>
-        </section>
+</section>
 
-        <!-- Embed hypothes.is to allow live annotation of the draft. Remove when publishing new spec version. -->
-        <script src="https://hypothes.is/embed.js" async></script>
-    </body>
+<section id="schemas">
+<h2>Validierung</h2>
+
+<section id="json-schema">
+<h2>JSON Schema</h2>
+<pre data-include="schemas/service-card.json" data-include-format="text"></pre>
+<a href="schemas/service-card.json">Link zum Schema</a>
+</section>
+
+</section>
+
+<section id="glossary" class="appendix" data-include="contents/glossary.md">
+<h2>Glossar</h2>
+</section>
+
+<!-- Embed hypothes.is to allow live annotation of the draft. Remove when publishing new spec version. -->
+<script src="https://hypothes.is/embed.js" async></script>
+</body>
 </html>


### PR DESCRIPTION
Wie in https://github.com/w3c/respec/issues/2850 erläutert, handelt es sich bei dem Bug #6 um eine Regression, für die es zwar einen Workaround, aber noch keinen Fix gibt. Dieser Pull-Request entfernt alle relevanten Einrückungen aus dem HTML, was den Fehler behebt, die Datei aber deutlich schwerer lesbar macht.

Alternativ können wir auch einfach abwarten, bis die Regression in ReSpec gefixt wurde, dann sollte das Dokument auch unverändert wieder funktionieren.